### PR TITLE
fix: correct struct sev_data_snp_launch_start

### DIFF
--- a/include/linux/psp-sev.h
+++ b/include/linux/psp-sev.h
@@ -604,8 +604,8 @@ struct sev_data_snp_launch_start {
 	u64 gctx_paddr;				/* In */
 	u64 policy;				/* In */
 	u64 ma_gctx_paddr;			/* In */
-	u32 ma_en:1;				/* In */
-	u32 imi_en:1;				/* In */
+	u32 ma_en:1,				/* In */
+	    imi_en:1;				/* In */
 	u32 rsvd:30;
 	u8 gosvw[16];				/* In */
 } __packed;


### PR DESCRIPTION
According to:

SEV Secure Nested Paging Firmware ABI Specification
Publication # 56860 Revision: 0.9
Issue Date: April 1, 2021
Page 68, Table 54. Layout of the CMDBUF_SNP_LAUNCH_START Structure

Signed-off-by: Harald Hoyer <harald@profian.com>