### PR TITLE
fix: correct struct sev_data_snp_launch_start

### DIFF
--- a/include/linux/psp-sev.h
+++ b/include/linux/psp-sev.h
@@ -607,6 +607,7 @@ struct sev_data_snp_launch_start {
 	u32 ma_en:1;				/* In */
 	u32 imi_en:1;				/* In */
 	u32 rsvd:30;
+	u32 rsvd2;
 	u8 gosvw[16];				/* In */
 } __packed;
 


### PR DESCRIPTION
According to:

SEV Secure Nested Paging Firmware ABI Specification
Publication # 56860 Revision: 0.9
Issue Date: April 1, 2021
Page 68, Table 54. Layout of the CMDBUF_SNP_LAUNCH_START Structure

old sizeof: 48
old gosvw offset: 28

new sizeof: 48
new gosvw offset: 32

Signed-off-by: Harald Hoyer <harald@profian.com>