### PR TITLE
Proof of concept for GHCB spec addition for throttling

### DIFF
--- a/arch/x86/include/asm/sev-common.h
+++ b/arch/x86/include/asm/sev-common.h
@@ -149,6 +149,12 @@ struct snp_psc_desc {
 #define GHCB_SEV_ES_PROT_UNSUPPORTED	1
 #define GHCB_SNP_UNSUPPORTED		2
 
+/* Error codes from hypervisor in EXITINFO[31:0] after VMGEXIT */
+#define VMGEXIT_RESULT_OK		0
+#define VMGEXIT_RESULT_EXCEPTION	1
+#define VMGEXIT_RESULT_BAD_INPUT	2
+#define VMGEXIT_RESULT_THROTTLED	3
+
 /* Linux-specific reason codes (used with reason set 1) */
 #define SEV_TERM_SET_LINUX		1
 #define GHCB_TERM_REGISTER		0	/* GHCB GPA registration failure */

--- a/arch/x86/kernel/sev-shared.c
+++ b/arch/x86/kernel/sev-shared.c
@@ -199,7 +199,7 @@ static enum es_result verify_exception_info(struct ghcb *ghcb, struct es_em_ctxt
 	if (!ret)
 		return ES_OK;
 
-	if (ret == 1) {
+	if (ret == VMGEXIT_RESULT_EXCEPTION) {
 		u64 info = ghcb->save.sw_exit_info_2;
 		unsigned long v;
 
@@ -217,6 +217,8 @@ static enum es_result verify_exception_info(struct ghcb *ghcb, struct es_em_ctxt
 
 			return ES_EXCEPTION;
 		}
+	} else if (ret == VMGEXIT_RESULT_THROTTLED) {
+		return ES_RETRY;
 	}
 
 	return ES_VMM_ERROR;

--- a/arch/x86/kernel/sev.c
+++ b/arch/x86/kernel/sev.c
@@ -2161,8 +2161,12 @@ int snp_issue_guest_request(u64 exit_code, struct snp_req_data *input, unsigned 
 	}
 
 	ret = sev_es_ghcb_hv_call(ghcb, true, &ctxt, exit_code, input->req_gpa, input->resp_gpa);
-	if (ret)
+	/* ret is an es_result at this point */
+	if (ret) {
+		if (ret == ES_RETRY)
+			ret = -EAGAIN;
 		goto e_put;
+	}
 
 	if (ghcb->save.sw_exit_info_2) {
 		/* Number of expected pages are returned in RBX */

--- a/drivers/virt/coco/sevguest/sevguest.c
+++ b/drivers/virt/coco/sevguest/sevguest.c
@@ -307,7 +307,7 @@ static int handle_guest_request(struct snp_guest_dev *snp_dev, u64 exit_code, in
 				u8 type, void *req_buf, size_t req_sz, void *resp_buf,
 				u32 resp_sz, __u64 *fw_err)
 {
-	unsigned long err;
+	unsigned long err = 0;
 	u64 seqno;
 	int rc;
 


### PR DESCRIPTION
When a VM makes too many requests too quickly for the host to allow, the host will want to return a helpful error that the guest has been throttled. The guest can then use that information to try again with exponential backoff.