### PR TITLE
crash: Disable SNP on crashkernel kexec

### DIFF
--- a/arch/x86/kernel/crash.c
+++ b/arch/x86/kernel/crash.c
@@ -25,6 +25,7 @@
 #include <linux/slab.h>
 #include <linux/vmalloc.h>
 #include <linux/memblock.h>
+#include <linux/psp-sev.h>
 
 #include <asm/processor.h>
 #include <asm/hardirq.h>
@@ -130,6 +131,16 @@ void native_machine_crash_shutdown(struct pt_regs *regs)
 	 */
 	/* The kernel is broken so disable interrupts */
 	local_irq_disable();
+
+	/*
+	 * Disable SEV/SNP to allow access to the reserved memory areas
+	 * including a normal IOMMU configuration
+	 * This needs to happen very early in the machine exit due to its
+	 * cross-cpu dependencies.
+	 */
+#ifdef CONFIG_AMD_SEV_SNP
+	sev_emergency_exit();
+#endif
 
 	crash_smp_send_stop();
 

--- a/include/linux/psp-sev.h
+++ b/include/linux/psp-sev.h
@@ -805,6 +805,14 @@ struct sev_data_snp_shutdown_ex {
 int sev_platform_init(int *error);
 
 /**
+ * sev_emergency_exit - perform SEV and SNP deinitialization
+ *
+ * Intended for emergency situations like kernel crashes
+ * enableing kdump on the incoming kernel without running SEV/SNP
+ */
+void sev_emergency_exit(void);
+
+/**
  * sev_platform_status - perform SEV PLATFORM_STATUS command
  *
  * @status: sev_user_data_status structure to be processed


### PR DESCRIPTION
### Context
We are running a backported version of the SNP host patches. We are not yet aligned with rfc-v9. We are building the snp support into the kernel instead of including it as a module

### Issue

We discovered that in case of a crash the incomming kdump crashkernel would be unable to boot once SNP was enabled, failing when it copied the outgoing kernels device table:

```
INFO [    0.006403] AMD-Vi: Copied DEV table from previous kernel.
ALERT [    0.115337] AMD-Vi: Completion-Wait loop timed out
ALERT [    0.224281] AMD-Vi: Completion-Wait loop timed out
ALERT [    0.333225] AMD-Vi: Completion-Wait loop timed out
ALERT [    0.442166] AMD-Vi: Completion-Wait loop timed out
ALERT [    0.551110] AMD-Vi: Completion-Wait loop timed out
ALERT [    0.660057] AMD-Vi: Completion-Wait loop timed out
ALERT [    0.769000] AMD-Vi: Completion-Wait loop timed out
ALERT [    0.877943] AMD-Vi: Completion-Wait loop timed out
ALERT [    0.988170] AMD-Vi: Completion-Wait loop timed out
INFO [    0.988344] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
ALERT [    1.097278] AMD-Vi: Completion-Wait loop timed out
ALERT [    1.206214] AMD-Vi: Completion-Wait loop timed out
ALERT [    1.315151] AMD-Vi: Completion-Wait loop timed out
EMERGENCY [    1.376701] Kernel panic - not syncing: timer doesn't work through Interrupt-remapped IO-APIC
```

This is happening due to the IRQ remapping configuration causing the crash in io_apic.c::check_timer() following early_enable_iommus().
This signature is therefore just the symptom and not the rootcause of the crashing crashkernel.

### Fix

We saw three options here:
1) We can disable the SNP on the incoming kernel before we load the old IOMMU tables
2) We disable SNP before we kexec into the crashkernel
3) We clean the old IOMMU tables

We descided to go with 2) because:
* The host kernel has access to the SNP configurations and can mark the IOMMU config pages shared again without too many memory accesses.
* The incoming kernel calls amd_iommu_early_init and similiar before the PCI driver for the PSP could ever have a chance to load to do the teardown
* The iommu would therefore stll configure  irqremapping into a completely nonsensical way leading to lapic init failing
* To filter out the SNP bits and bringing the iommu device tables into a sane state appears to us as the more involved and higher-risk approach, especially without immediate access to the hosts iommu data pointers.

### Note:

The incoming crashkernel would still not boot in our testing failing on the SNP enablement which we solved for us by kexec-ing with initcall_blacklist=sp_mod_init as we dont need SNP support in the crashkernel:

```
INFO [    5.253326] tsc: Refined TSC clocksource calibration: 2599.999 MHz
INFO [    5.253333] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x257a3b2ad7e, max_idle_ns: 440795282337 ns
INFO [    5.253346] clocksource: Switched to clocksource tsc
ALERT [   12.349310] BUG: unable to handle page fault for address: ffff95cb77f75018
ALERT [   12.349316] #PF: supervisor write access in kernel mode
ALERT [   12.349319] #PF: error_code(0x80000003) - RMP violation
INFO [   12.349322] PGD 77201067 P4D 77201067 PUD 77205067 PMD 8000000077e001e3
INFO [   12.349328] SEV-SNP: RMPEntry paddr 0x77e00000: [high=0x0000000000000000 low=0x0000000000000030]
INFO [   12.349348] SEV-SNP: RMPEntry paddr 0x77f22000: [high=0x0000000000000000 low=0x8002000000001005]
INFO [   12.349352] SEV-SNP: RMPEntry paddr 0x77f23000: [high=0x0000000000000000 low=0x8002000000001005]
INFO [   12.349356] SEV-SNP: RMPEntry paddr 0x77f28000: [high=0x0000000000000000 low=0x8002000000001005]
INFO [   12.349360] SEV-SNP: RMPEntry paddr 0x77f29000: [high=0x0000000000000000 low=0x8002000000001005]
INFO [   12.349363] SEV-SNP: RMPEntry paddr 0x77f2e000: [high=0x0000000000000000 low=0x8002000000001005]
INFO [   12.349367] SEV-SNP: RMPEntry paddr 0x77f2f000: [high=0x0000000000000000 low=0x8002000000001005]
WARNING [   12.349383] Oops: 0003 [#1] SMP NOPTI
WARNING [   12.349386] CPU: 0 PID: 0 Comm: swapper/0 Not tainted XXX
WARNING [   12.349390] Hardware name: XXX
WARNING [   12.349397] RIP: 0010:cpuidle_enter_state+0xf0/0x370
[...]
EMERGENCY [   12.349505] Kernel panic - not syncing: Fatal exception
EMERGENCY [   12.349512] Kernel Offset: 0x2e000000 from 0xffffffff81000000 (relocation range: 0xffffffff80000000-0xffffffffbfffffff)
EMERGENCY [   12.349516] ---[ end Kernel panic - not syncing: Fatal exception ]---
```

The persistence of invalid RMP entries over SNP de-init and re-init seems to us like either an general issue or like an downstream problem. We assume this did not show up during your kexec testing?

=====================================================

### Commit message:

The crashkernel is tasked with two problems as it stands right now: During start it will read the SNP enabled IOMMU tables during early init which can cause the lapic configuration to be configured into invalid or unintuitive modes.
This will then cause the crashkernel to panic due to the lapic timer calibration failing or general RCU stalling.
As the crashkernel can not pick up the host kernels PSP/SEV/SNP configuration we are therefore disabeling SNP not only on the normal kexec path but also on crash-kexec.

This needs to be called very early on in the machine teardown as it requires to set per-cpu state.

Signed-off-by: Mimoja <git@mimoja.de>
Signed-off-by: Johanna 'Mimoja' Amelie Schander <mimoja@amazon.com>